### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ GDRSImageCache suports ios versions of ```5.0``` and above.
 
 ###Manual installation
 
-Drag and drop following four files from the ```GDRSImageCache``` directory into XCode in the Project Navigator:
+Drag and drop following four files from the ```GDRSImageCache``` directory into Xcode in the Project Navigator:
 
 * GDRSImageCache.h
 * GDRSImageCache.m


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
